### PR TITLE
deprecated initial_state arg to fix #56

### DIFF
--- a/src/simulators/history_recorder.jl
+++ b/src/simulators/history_recorder.jl
@@ -13,10 +13,13 @@ Keyword Arguments:
     - `rng`: The random number generator for the simulation
     - `capture_exception::Bool`: whether to capture an exception and store it in the history, or let it go uncaught, potentially killing the script
     - `show_progress::Bool`: show a progress bar for the simulation
-    - `initial_state`
     - `eps`
     - `max_steps`
     - `sizehint::Int`: the expected length of the simulation (for preallocation)
+
+Usage (optional arguments in brackets):
+    hr = HistoryRecorder()
+    history = simulate(hr, pomdp, policy, [updater [, init_belief [, init_state]]])
 """
 mutable struct HistoryRecorder <: Simulator
     rng::AbstractRNG
@@ -26,10 +29,12 @@ mutable struct HistoryRecorder <: Simulator
     show_progress::Bool
 
     # optional: if these are null, they will be ignored
-    initial_state::Nullable{Any}
     eps::Nullable{Any}
     max_steps::Nullable{Any}
     sizehint::Nullable{Integer}
+
+    # DEPRECATED
+    initial_state::Nullable{Any}
 end
 
 function HistoryRecorder(;rng=MersenneTwister(rand(UInt32)),
@@ -39,7 +44,10 @@ function HistoryRecorder(;rng=MersenneTwister(rand(UInt32)),
                           sizehint=Nullable{Integer}(),
                           capture_exception=false,
                           show_progress=false)
-    return HistoryRecorder(rng, capture_exception, show_progress, initial_state, eps, max_steps, sizehint)
+    if !isnull(initial_state)
+        warn("The initial_state argument for HistoryRecorder is deprecated. The initial state should be specified as the last argument to simulate(...).")
+    end
+    return HistoryRecorder(rng, capture_exception, show_progress, eps, max_steps, sizehint, initial_state)
 end
 
 @POMDP_require simulate(sim::HistoryRecorder, pomdp::POMDP, policy::Policy) begin

--- a/src/simulators/rollout.jl
+++ b/src/simulators/rollout.jl
@@ -9,28 +9,33 @@ The simulation will be terminated when either
 2) the discount factor is as small as `eps` or
 3) max_steps have been executed
 
-Keyword arguments are:
+Keyword Arguments:
+    - eps
+    - max_steps
 
-    initial_state
-    
-    eps
-
-    max_steps
+Usage (optional arguments in brackets):
+    ro = RolloutSimulator()
+    history = simulate(ro, pomdp, policy, [updater [, init_belief [, init_state]]])
 """
 struct RolloutSimulator{RNG<:AbstractRNG} <: Simulator
     rng::RNG
 
     # optional: if these are null, they will be ignored
-    initial_state::Nullable{Any}
     eps::Nullable{Float64}
     max_steps::Nullable{Int}
+
+    # DEPRECATED
+    initial_state::Nullable{Any}
 end
-RolloutSimulator(rng::AbstractRNG) = RolloutSimulator(rng, Nullable{Any}(), Nullable{Float64}(), Nullable{Int}())
+RolloutSimulator(rng::AbstractRNG) = RolloutSimulator(rng, Nullable{Float64}(), Nullable{Int}(), Nullable{Any}())
 function RolloutSimulator(;rng=MersenneTwister(rand(UInt32)),
                            initial_state=Nullable{Any}(),
                            eps=Nullable{Float64}(),
                            max_steps=Nullable{Int}())
-    return RolloutSimulator{typeof(rng)}(rng, initial_state, eps, max_steps)
+    if !isnull(initial_state)
+        warn("The initial_state argument for RolloutSimulator is deprecated. The initial state should be specified as the last argument to simulate(...).")
+    end
+    return RolloutSimulator{typeof(rng)}(rng, eps, max_steps, initial_state)
 end
 
 @POMDP_require simulate(sim::RolloutSimulator, pomdp::POMDP, policy::Policy) begin

--- a/src/simulators/sim.jl
+++ b/src/simulators/sim.jl
@@ -40,16 +40,18 @@ function sim(polfunc::Function, mdp::MDP,
              simulator=nothing,
              kwargs...
             )
+
     kwargd = Dict(kwargs)
-    if simulator==nothing
-        simulator = HistoryRecorder(;kwargs...)
-    end
     if initial_state==nothing && state_type(mdp) != Void
         if haskey(kwargd, :initial_state)
-            initial_state = kwargd[:initial_state]
+            initial_state = pop!(kwargd, :initial_state)
         else
             initial_state = default_init_state(mdp)
         end    
+    end
+    delete!(kwargd, :initial_state)
+    if simulator==nothing
+        simulator = HistoryRecorder(;kwargd...) # kwargd does not contain :initial_state because it was popped
     end
     policy = FunctionPolicy(polfunc)
     simulate(simulator, mdp, policy, initial_state)
@@ -62,16 +64,18 @@ function sim(polfunc::Function, pomdp::POMDP,
              updater=nothing,
              kwargs...
             )
+
     kwargd = Dict(kwargs)
-    if simulator==nothing
-        simulator = HistoryRecorder(;initial_state=initial_state, kwargs...)
-    end
     if initial_state==nothing && state_type(pomdp) != Void
         if haskey(kwargd, :initial_state)
-            initial_state = kwargd[:initial_state]
+            initial_state = pop!(kwargd, :initial_state)
         else
             initial_state = default_init_state(pomdp)
         end    
+    end
+    delete!(kwargd, :initial_state)
+    if simulator==nothing
+        simulator = HistoryRecorder(;kwargd...)
     end
     if initial_obs==nothing && obs_type(pomdp) != Void
         initial_obs = default_init_obs(pomdp, initial_state)
@@ -80,7 +84,7 @@ function sim(polfunc::Function, pomdp::POMDP,
         updater = PrimedPreviousObservationUpdater{Any}(initial_obs)
     end
     policy = FunctionPolicy(polfunc)
-    simulate(simulator, pomdp, policy, updater)
+    simulate(simulator, pomdp, policy, updater, initial_obs, initial_state)
 end
 
 function default_init_obs(p::POMDP, s)

--- a/test/test_rollout.jl
+++ b/test/test_rollout.jl
@@ -9,8 +9,8 @@ let
     sim = RolloutSimulator(max_steps=10, rng=MersenneTwister(1))
     r1 = @inferred simulate(sim, problem, policy, updater(policy), initial_state_distribution(problem))
 
-    sim = RolloutSimulator(max_steps=10, rng=MersenneTwister(1), initial_state=true)
-    dummy = @inferred simulate(sim, problem, policy, updater(policy), nothing)
+    sim = RolloutSimulator(max_steps=10, rng=MersenneTwister(1))
+    dummy = @inferred simulate(sim, problem, policy, updater(policy), nothing, true)
 
     problem = GridWorld()
     solver = RandomSolver(rng=MersenneTwister(1))


### PR DESCRIPTION
Deprecated the inital_state keyword argument for RolloutSimulator and HistoryRecorder. It only made sense when the official signature of the pomdp version of simulate didn't allow for an initial state.