### PR TITLE
ValuePolicy type parameterization

### DIFF
--- a/src/policies/vector.jl
+++ b/src/policies/vector.jl
@@ -19,9 +19,9 @@ mutable struct VectorSolver{A}
     act::Vector{A}
 end
 
-create_policy{S,A}(s::VectorSolver{A}, mdp::MDP{S,A}) = VectorPolicy(mdp, Array{A}(0))
+create_policy(s::VectorSolver{A}, mdp::MDP{S,A}) where {S,A} = VectorPolicy(mdp, Array{A}(0))
 
-function solve{S,A}(s::VectorSolver{A}, mdp::MDP{S,A}, p::VectorPolicy=create_policy(s,mdp))
+function solve(s::VectorSolver, mdp::MDP, p::VectorPolicy=create_policy(s,mdp))
     p.mdp = mdp
     p.act = s.act
     return p
@@ -36,7 +36,7 @@ mutable struct ValuePolicy{A, P <: Union{MDP, POMDP}} <: Policy
     value_table::Matrix{Float64}
     act::Vector{A}
 end
-function ValuePolicy{P <: Union{MDP, POMDP}}(mdp::P)
+function ValuePolicy(mdp::P) where {P <: Union{MDP, POMDP}}
     A = action_type(mdp)
     return ValuePolicy{A, P}(mdp, zeros(n_states(mdp), n_actions(mdp)), ordered_actions(mdp))
 end

--- a/src/policies/vector.jl
+++ b/src/policies/vector.jl
@@ -31,13 +31,14 @@ end
 """
 A generic MDP policy that consists of a value table. The entry at `state_index(mdp, s)` is the action that will be taken in state `s`.
 """
-mutable struct ValuePolicy{A} <: Policy
-    mdp::Union{MDP,POMDP}
+mutable struct ValuePolicy{A, P <: Union{MDP, POMDP}} <: Policy
+    mdp::P
     value_table::Matrix{Float64}
     act::Vector{A}
 end
-function ValuePolicy(mdp::Union{MDP,POMDP})
-    return ValuePolicy(mdp, zeros(n_states(mdp), n_actions(mdp)), ordered_actions(mdp))
+function ValuePolicy{P <: Union{MDP, POMDP}}(mdp::P)
+    A = action_type(mdp)
+    return ValuePolicy{A, P}(mdp, zeros(n_states(mdp), n_actions(mdp)), ordered_actions(mdp))
 end
 
 action(p::ValuePolicy, s) = p.act[indmax(p.value_table[state_index(p.mdp, s),:])]


### PR DESCRIPTION
This a fix to #61

To verify that it actually works one can use [Traceur.jl](https://github.com/MikeInnes/Traceur.jl) as follows:
```julia
using POMDPs, POMDPToolbox, POMDPModels, Traceur
gw = GridWorld()
s = initial_state(gw, MersenneTwister(4))
policy = ValuePolicy(gw)
@trace action(policy, s)
```

Output of `@trace` before the fix:
```
(Base.indexed_next)(::Tuple{Float64,Int64}, ::Int64, ::Int64) at tuple.jl:54
  returns Tuple{Union{Float64, Int64},Int64}
(POMDPs.action)(::POMDPToolbox.ValuePolicy{Symbol}, ::POMDPModels.GridWorldState) at /mnt/c/Users/Maxime/wsl/.julia/v0.6/POMDPToolbox/src/policies/vector.jl:43
  dynamic dispatch to (POMDPToolbox.state_index)((Core.getfield)(p, :mdp), s) at line 43
```

Output of `@trace` after the fix:
```
(Base.indexed_next)(::Tuple{Float64,Int64}, ::Int64, ::Int64) at tuple.jl:54
  returns Tuple{Union{Float64, Int64},Int64}
```

