### PR TITLE
Some helpful functions to work with alpha vector policies

### DIFF
--- a/src/POMDPToolbox.jl
+++ b/src/POMDPToolbox.jl
@@ -16,6 +16,7 @@ import DataStructures: CircularBuffer, isfull, capacity, push!, append!
 using ProgressMeter
 using StatsBase
 using DataFrames
+using ParticleFilters
 
 
 # export commons
@@ -70,7 +71,9 @@ include("convenience/implementations.jl")
 
 # policies
 export
-    AlphaVectorPolicy
+    AlphaVectorPolicy,
+    belief_vector,
+    unnormalized_util
 include("policies/alpha_vector.jl")
 
 export

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 POMDPModels
+ParticleFilters

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using POMDPs
 using POMDPToolbox
 using POMDPModels
+using ParticleFilters
 using Base.Test
 
 include("test_random_solver.jl")

--- a/test/test_alpha_policy.jl
+++ b/test/test_alpha_policy.jl
@@ -14,8 +14,14 @@ policy = AlphaVectorPolicy(pomdp, alphas)
 # because baby isn't hungry, policy should not feed (return false)
 @test action(policy, b0) == false
 
+# try other belief type 
+b = ParticleCollection([true for i=1:100])
+@test action(policy, b) == true
+@test isapprox(value(policy, b), -29.4557)
+
 # try pushing new vector
 push!(policy, [0.0,0.0], true)
 
 @test value(policy, b0) == 0.0
 @test action(policy, b0) == true
+


### PR DESCRIPTION
They were originally implemented in the QMDP module but I think they belong in POMDPToolbox since they are generic helper functions for alpha vector policies. 

This is related to JuliaPOMDP/QMDP.jl#8